### PR TITLE
fix bug due to missing env

### DIFF
--- a/.github/workflows/gha_check_duplicate.yml
+++ b/.github/workflows/gha_check_duplicate.yml
@@ -20,4 +20,6 @@ jobs:
     
       - name: Parsing issue and check duplicate
         shell: bash -l {0}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # for label posting
         run: python new_link_check.py


### PR DESCRIPTION
The GitHub token env is missing when calling the python script. The env is provided in the yml file that trigger the GitHub action