### PR TITLE
Update cefi_list.json

### DIFF
--- a/data/cefi_list.json
+++ b/data/cefi_list.json
@@ -2330,9 +2330,9 @@
             ]
         },
         {
-            "url": "http://hfrnet.ucsd.edu/thredds/catalog.html",
-            "title": "High Frequency (HF) Radar Distributed Archive Center (DAC) THREDDS: UCSD Scripps Institution of Oceanography",
-            "desc": "High Frequency (HF) Radar DAC THREDDS access",
+            "url": "https://dods.ndbc.noaa.gov/thredds/catalog/hfradar.html",
+            "title": "IOOS High Frequency (HF) Radar Distributed Archive Center (DAC) THREDDS: NDBC",
+            "desc": "IOOS High Frequency (HF) Radar DAC THREDDS access",
             "thumbnail": "images/SIO_logo.png",
             "ctype": [],
             "cdata": [],


### PR DESCRIPTION
hfrnet is moving this updates the thredds link to the right place. See https://ioos.noaa.gov/project/hf-radar/#tab-v3-1pt8jfh7-5 for more information.

Should probably update the .png too...